### PR TITLE
Update README with installation and experimentation scripts filenames

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ We received feedback from other researchers that our orthogonality initializatio
  * Install anaconda: https://www.anaconda.com/distribution/
  * set up conda environment w/ python 3.8, ex: `conda create --name coda python=3.8`
  * `conda activate coda`
- * `sh install_requirements.sh`
+ * `sh install-requirements.sh`
  * <b>NOTE: this framework was tested using `torch == 2.0.0` but should work for previous versions</b>
  
 ## Datasets

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ We received feedback from other researchers that our orthogonality initializatio
 All commands should be run under the project root directory. **The scripts are set up for 4 GPUs** but can be modified for your hardware.
 
 ```bash
-sh experiments/cifar100.sh
+sh experiments/cifar-100.sh
 sh experiments/imagenet-r.sh
 sh experiments/domainnet.sh
 ```


### PR DESCRIPTION
The previous readme had a few typos that made the entry barrier for beginners difficult. This updates those filenames with recent changes made:
cifar100.sh should be cifar-100.sh
install_requirements.sh should be install-requirements.sh